### PR TITLE
fix for lua-nginx-module version >= v0.5.10

### DIFF
--- a/lib/resty/template.lua
+++ b/lib/resty/template.lua
@@ -104,19 +104,20 @@ local function loadngx(path)
     end
     local root = vars and (var.template_root or var.document_root) or prefix
     if sub(root, -1) == "/" then root = sub(root, 1, -2) end
-    return readfile(concat{ root, "/", file }) or path
+    local fullpath = concat{ root, "/", file } 
+    return readfile(fullpath) or fullpath
 end
 
 do
     if ngx then
         VAR_PHASES = {
-            set_by_lua           = true,
-            rewrite_by_lua       = true,
-            access_by_lua        = true,
-            content_by_lua       = true,
-            header_filter_by_lua = true,
-            body_filter_by_lua   = true,
-            log_by_lua           = true
+            set           = true,
+            rewrite       = true,
+            access        = true,
+            content       = true,
+            header_filter = true,
+            body_filter   = true,
+            log           = true
         }
         template.print = ngx.print or write
         template.load  = loadngx


### PR DESCRIPTION
i like this library. and use it in out project. but lua-nginx-module update the get_phase() return value, this made wrong template path. 
below is from lua-nginx-module offical.

ngx.get_phase
-------------
**syntax:** *str = ngx.get_phase()*

**context:** *init_by_lua&#42;, init_worker_by_lua&#42;, set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;, ngx.timer.&#42;, balancer_by_lua&#42;, ssl_certificate_by_lua&#42;*

Retrieves the current running phase name. Possible return values are

* `init`
	for the context of [init_by_lua](#init_by_lua) or [init_by_lua_file](#init_by_lua_file).
* `init_worker`
	for the context of [init_worker_by_lua](#init_worker_by_lua) or [init_worker_by_lua_file](#init_worker_by_lua_file).
* `set`
	for the context of [set_by_lua](#set_by_lua) or [set_by_lua_file](#set_by_lua_file).
* `rewrite`
	for the context of [rewrite_by_lua](#rewrite_by_lua) or [rewrite_by_lua_file](#rewrite_by_lua_file).
* `access`
	for the context of [access_by_lua](#access_by_lua) or [access_by_lua_file](#access_by_lua_file).
* `content`
	for the context of [content_by_lua](#content_by_lua) or [content_by_lua_file](#content_by_lua_file).
* `header_filter`
	for the context of [header_filter_by_lua](#header_filter_by_lua) or [header_filter_by_lua_file](#header_filter_by_lua_file).
* `body_filter`
	for the context of [body_filter_by_lua](#body_filter_by_lua) or [body_filter_by_lua_file](#body_filter_by_lua_file).
* `log`
	for the context of [log_by_lua](#log_by_lua) or [log_by_lua_file](#log_by_lua_file).
* `timer`
	for the context of user callback functions for [ngx.timer.*](#ngxtimerat).

This API was first introduced in the `v0.5.10` release.