### PR TITLE
Handle errors of file IO

### DIFF
--- a/lib/resty/template.lua
+++ b/lib/resty/template.lua
@@ -27,6 +27,7 @@ local var
 local _VERSION = _VERSION
 local _ENV = _ENV
 local _G = _G
+local ENOENT = 2
 
 local HTML_ENTITIES = {
     ["&"] = "&amp;",
@@ -92,10 +93,16 @@ local function escaped(view, s)
 end
 
 local function readfile(path)
-    local file = open(path, "rb")
+    local file, err, errno = open(path, "rb")
+    if err and errno ~= ENOENT then
+      error(err)
+    end
     if not file then return nil end
-    local content = file:read "*a"
+    local content, read_err = file:read "*a"
     file:close()
+    if not content then
+      error(read_err)
+    end
     return content
 end
 


### PR DESCRIPTION
This PR fixes the problem that `template.render("template.html")` can print the `template.html` string as the rendering result when an error happened on file load.

Unfortunately, this PR is not a perfect solution because it can still render a file name when the file doesn't exist. This module should support a method for treating only file paths something like `template.renderfile` IMHO. Additionally, I hope the methods to return an error as a result like `ok, err = template.render()`.

I know that you can define your own `template.load` but it's troublesome since the `loadngx` module is not that simple. Hope having a nicer default.