### PR TITLE
feat(eval) add eval functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ template.print = function(s)
 end
 ```
 
-#### template.eval(exp, ctx)
+#### template.eval(exp)
 
 This field is used to intercept expressions pre-execution in order to extend or change behavior. This function is only called for expressions within `{{ }}` and `{* *}` delimiters.  `exp` is the string representation of the expression. `template.eval` should return a valid lua expression represented as a string.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ template.render([[
   * [template.precompile](#string-templateprecompileview-path-strip)
   * [template.load](#templateload)
   * [template.print](#templateprint)
-  * [template.tag_hook](#templatetag-hook)
+  * [template.eval](#templateeval)
 * [Template Precompilation](#template-precompilation)
 * [Template Helpers](#template-helpers)
 * [Usage Examples](#usage-examples)
@@ -509,9 +509,9 @@ template.print = function(s)
 end
 ```
 
-#### template.tag_hook(type, arg, ctx)
+#### template.eval(type, arg, ctx)
 
-This field is used to intercept expressions pre-execution in order to extend or change behavior.  The first argument `type` contains the byte representation of the current expressions delimiter.  Type can be inferred by running `string.char(type)`, or by comparing directly to the `template.tag_types` table. `arg` is a string representation of the primary argument of the expression, for `{{ }}`, `{* *}`, and `{()}` delimiters this will be the only argument. `ctx` represents the string representation of additional context for the expression. `{()}` and `{[]}` expressions can take a ctx argument in particular. `template.tag_hook` should return `arg` and optionally `ctx` as strings.
+This field is used to intercept expressions pre-execution in order to extend or change behavior.  The first argument `type` contains the string representation of the current expressions delimiter.  `arg` is a string representation of the primary argument of the expression, for `{{ }}` and `{* *}` delimiters this will be the only argument. `ctx` represents the string representation of additional context for the expression. `{()}` and `{[]}` expressions can take a ctx argument in particular. `template.eval` should return `arg` and optionally `ctx` as strings.
 
 ```lua
 -- setup "safe" function, allowing for expression to evaluate safely
@@ -525,10 +525,9 @@ template.safe = function(cb)
   return res
 end
 
-template.tag_hook = function(type, ...)
-  local tags = template.tag_types
+template.eval = function(type, ...)
   -- only run when '{{ }}' or '{* *}' delimiter types
-  if type == tags.LCUB or type == tags.AST then
+  if type == "{" or type == "*" then
     local exp = ...
     -- call helper function established above
     return "template.safe(function() return " .. exp .. " end)"

--- a/README.md
+++ b/README.md
@@ -509,9 +509,9 @@ template.print = function(s)
 end
 ```
 
-#### template.eval(type, arg, ctx)
+#### template.eval(exp, ctx)
 
-This field is used to intercept expressions pre-execution in order to extend or change behavior.  The first argument `type` contains the string representation of the current expressions delimiter.  `arg` is a string representation of the primary argument of the expression, for `{{ }}` and `{* *}` delimiters this will be the only argument. `ctx` represents the string representation of additional context for the expression. `{()}` and `{[]}` expressions can take a ctx argument in particular. `template.eval` should return `arg` and optionally `ctx` as strings.
+This field is used to intercept expressions pre-execution in order to extend or change behavior. `exp` is a string representation of the primary argument of the expression, for `{{ }}` and `{* *}` delimiters this will be the only argument. `ctx` represents the string representation of additional context for the expression. `{[]}` expressions can take a ctx argument in particular. `template.eval` should return `arg` and optionally `ctx` as strings.
 
 ```lua
 -- setup "safe" function, allowing for expression to evaluate safely
@@ -525,15 +525,13 @@ template.safe = function(cb)
   return res
 end
 
-template.eval = function(type, ...)
-  -- only run when '{{ }}' or '{* *}' delimiter types
-  if type == "{" or type == "*" then
-    local exp = ...
+template.eval = function(exp, ctx)
+  if not ctx then
     -- call helper function established above
     return "template.safe(function() return " .. exp .. " end)"
   end
 
-  return ...
+  return exp, ctx
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ end
 
 #### template.eval(exp, ctx)
 
-This field is used to intercept expressions pre-execution in order to extend or change behavior. `exp` is a string representation of the primary argument of the expression, for `{{ }}` and `{* *}` delimiters this will be the only argument. `ctx` represents the string representation of additional context for the expression. `{[]}` expressions can take a ctx argument in particular. `template.eval` should return `arg` and optionally `ctx` as strings.
+This field is used to intercept expressions pre-execution in order to extend or change behavior. This function is only called for expressions within `{{ }}` and `{* *}` delimiters.  `exp` is the string representation of the expression. `template.eval` should return a valid lua expression represented as a string.
 
 ```lua
 -- setup "safe" function, allowing for expression to evaluate safely
@@ -525,13 +525,8 @@ template.safe = function(cb)
   return res
 end
 
-template.eval = function(exp, ctx)
-  if not ctx then
-    -- call helper function established above
-    return "template.safe(function() return " .. exp .. " end)"
-  end
-
-  return exp, ctx
+template.eval = function(exp)
+  return "template.safe(function() return " .. exp .. " end)"
 end
 ```
 

--- a/lib/resty/template.lua
+++ b/lib/resty/template.lua
@@ -181,7 +181,7 @@ do
     end
 end
 
-function template.eval(type, ...)
+function template.eval(...)
   return ...
 end
 
@@ -282,7 +282,6 @@ local ___,blocks,layout={},blocks or {}
 ]] }
     local i, s = 1, find(view, "{", 1, true)
     local eval = template.eval
-    local ctx
     while s do
         local t, p = byte(view, s + 1, s + 1), s + 2
         if t == LCUB then
@@ -298,9 +297,9 @@ local ___,blocks,layout={},blocks or {}
                 if z then
                     i = s
                 else
-                  ctx = trim(sub(view, p, e - 1))
+                  local exp = trim(sub(view, p, e - 1))
                   c[j] = "___[#___+1]=template.escape("
-                  c[j+1] = eval("{", ctx)
+                  c[j+1] = eval(exp)
                   c[j+2] = ")\n"
                   j=j+3
                   s, i = e + 1, e + 2
@@ -319,9 +318,9 @@ local ___,blocks,layout={},blocks or {}
                 if z then
                     i = s
                 else
-                    ctx = trim(sub(view, p, e - 1))
+                    local exp = trim(sub(view, p, e - 1))
                     c[j] = "___[#___+1]=template.output("
-                    c[j+1] = eval("*", ctx)
+                    c[j+1] = eval(exp)
                     c[j+2] = ")\n"
                     j=j+3
                     s, i = e + 1, e + 2
@@ -351,8 +350,7 @@ local ___,blocks,layout={},blocks or {}
                         c[j+2] = "]=]\n"
                         j=j+3
                     end
-                    ctx = trim(sub(view, p, e - 1))
-                    c[j] = eval("%", ctx)
+                    c[j] = trim(sub(view, p, e - 1))
                     c[j+1] = "\n"
                     j=j+2
                     s, i = n - 1, n
@@ -374,17 +372,16 @@ local ___,blocks,layout={},blocks or {}
                     local f = sub(view, p, e - 1)
                     local x = find(f, ",", 2, true)
                     if x then
-                        f, x = eval("(", trim(sub(f, 1, x - 1)), trim(sub(f, x + 1)))
                         c[j] = "___[#___+1]=include([=["
-                        c[j+1] = f
+                        c[j+1] = trim(sub(f, 1, x - 1))
                         c[j+2] = "]=],"
-                        c[j+3] = x
+                        c[j+3] = trim(sub(f, x + 1))
                         c[j+4] = ")\n"
                         j=j+5
                     else
                         ctx = trim(f)
                         c[j] = "___[#___+1]=include([=["
-                        c[j+1] = eval("(", ctx)
+                        c[j+1] = trim(f)
                         c[j+2] = "]=])\n"
                         j=j+3
                     end
@@ -404,9 +401,9 @@ local ___,blocks,layout={},blocks or {}
                 if z then
                     i = s
                 else
-                    ctx = trim(sub(view, p, e - 1))
+                    local exp = trim(sub(view, p, e - 1))
                     c[j] = "___[#___+1]=include("
-                    c[j+1] = eval("[", ctx)
+                    c[j+1] = eval("[", exp)
                     c[j+2] = ")\n"
                     j=j+3
                     s, i = e + 1, e + 2

--- a/lib/resty/template.lua
+++ b/lib/resty/template.lua
@@ -77,7 +77,6 @@ local template = newtab(0, 13)
 template._VERSION = "2.0"
 template.cache    = {}
 
-
 local function enabled(val)
     if val == nil then return true end
     return val == true or (val == "1" or val == "true" or val == "on")

--- a/lib/resty/template.lua
+++ b/lib/resty/template.lua
@@ -181,9 +181,7 @@ do
     end
 end
 
-function template.eval(...)
-  return ...
-end
+function template.eval(exp) return exp end
 
 function template.caching(enable)
     if enable ~= nil then caching = enable == true end
@@ -379,7 +377,6 @@ local ___,blocks,layout={},blocks or {}
                         c[j+4] = ")\n"
                         j=j+5
                     else
-                        ctx = trim(f)
                         c[j] = "___[#___+1]=include([=["
                         c[j+1] = trim(f)
                         c[j+2] = "]=])\n"
@@ -401,9 +398,8 @@ local ___,blocks,layout={},blocks or {}
                 if z then
                     i = s
                 else
-                    local exp = trim(sub(view, p, e - 1))
                     c[j] = "___[#___+1]=include("
-                    c[j+1] = eval("[", exp)
+                    c[j+1] = trim(sub(view, p, e - 1))
                     c[j+2] = ")\n"
                     j=j+3
                     s, i = e + 1, e + 2

--- a/lib/resty/template.lua
+++ b/lib/resty/template.lua
@@ -72,19 +72,10 @@ local ok, newtab = pcall(require, "table.new")
 if not ok then newtab = function() return {} end end
 
 local caching = true
-local template = newtab(0, 14)
+local template = newtab(0, 13)
 
 template._VERSION = "2.0"
 template.cache    = {}
-template.tag_types = {
-  AST = AST,
-  NUM = NUM,
-  LPAR = LPAR,
-  LSQB = LSQB,
-  LCUB = LCUB,
-  MINUS = MINUS,
-  PERCNT = PERCNT,
-}
 
 
 local function enabled(val)
@@ -191,7 +182,7 @@ do
     end
 end
 
-function template.tag_hook(type, ...)
+function template.eval(type, ...)
   return ...
 end
 
@@ -291,7 +282,7 @@ local function include(v, c) return template.compile(v)(c or context) end
 local ___,blocks,layout={},blocks or {}
 ]] }
     local i, s = 1, find(view, "{", 1, true)
-    local hook = template.tag_hook
+    local eval = template.eval
     local ctx
     while s do
         local t, p = byte(view, s + 1, s + 1), s + 2
@@ -310,7 +301,7 @@ local ___,blocks,layout={},blocks or {}
                 else
                   ctx = trim(sub(view, p, e - 1))
                   c[j] = "___[#___+1]=template.escape("
-                  c[j+1] = hook(LCUB, ctx)
+                  c[j+1] = eval("{", ctx)
                   c[j+2] = ")\n"
                   j=j+3
                   s, i = e + 1, e + 2
@@ -331,7 +322,7 @@ local ___,blocks,layout={},blocks or {}
                 else
                     ctx = trim(sub(view, p, e - 1))
                     c[j] = "___[#___+1]=template.output("
-                    c[j+1] = hook(AST, ctx)
+                    c[j+1] = eval("*", ctx)
                     c[j+2] = ")\n"
                     j=j+3
                     s, i = e + 1, e + 2
@@ -362,7 +353,7 @@ local ___,blocks,layout={},blocks or {}
                         j=j+3
                     end
                     ctx = trim(sub(view, p, e - 1))
-                    c[j] = hook(PERCNT, ctx)
+                    c[j] = eval("%", ctx)
                     c[j+1] = "\n"
                     j=j+2
                     s, i = n - 1, n
@@ -384,7 +375,7 @@ local ___,blocks,layout={},blocks or {}
                     local f = sub(view, p, e - 1)
                     local x = find(f, ",", 2, true)
                     if x then
-                        f, x = hook(LPAR, trim(sub(f, 1, x - 1)), trim(sub(f, x + 1)))
+                        f, x = eval("(", trim(sub(f, 1, x - 1)), trim(sub(f, x + 1)))
                         c[j] = "___[#___+1]=include([=["
                         c[j+1] = f
                         c[j+2] = "]=],"
@@ -394,7 +385,7 @@ local ___,blocks,layout={},blocks or {}
                     else
                         ctx = trim(f)
                         c[j] = "___[#___+1]=include([=["
-                        c[j+1] = hook(LPAR, ctx)
+                        c[j+1] = eval("(", ctx)
                         c[j+2] = "]=])\n"
                         j=j+3
                     end
@@ -416,7 +407,7 @@ local ___,blocks,layout={},blocks or {}
                 else
                     ctx = trim(sub(view, p, e - 1))
                     c[j] = "___[#___+1]=include("
-                    c[j+1] = hook(LSQB, ctx)
+                    c[j+1] = eval("[", ctx)
                     c[j+2] = ")\n"
                     j=j+3
                     s, i = e + 1, e + 2


### PR DESCRIPTION
`template.eval` provides a hook to modify expressions before they evaluate.  This can be useful for custom error handling, logging, and implementing policies without cluttering templating syntax.

The function takes two arguments:
- `exp` (string): primary expression argument

The return value expects an `exp` with type string.

Example in README.md