### PR TITLE
set the content length

### DIFF
--- a/lib/resty/template.lua
+++ b/lib/resty/template.lua
@@ -649,7 +649,9 @@ local function echo(...) for i=1,select("#", ...) do ___[#___+1] = tostring(sele
 
     function template.render(view, context, cache_key, plain)
         assert(view, "view was not provided for template.render(view, context, cache_key, plain)")
-        template.print(template.process(view, context, cache_key, plain))
+        local body = template.process(view, context, cache_key, plain)
+        ngx.header["Content-Length"] = #body
+        template.print(body)
     end
 
     function template.render_file(view, context, cache_key)


### PR DESCRIPTION
I'm not sure if there's a reason _not_ to do this? By setting the content length, we're no longer relying on chunked encoding which, all other things being equal, I think is a win.