### PR TITLE
Support sandboxed environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # lua-resty-template
 
-**lua-resty-template** is a compiling (1) (HTML) templating engine for Lua and OpenResty.
+**lua-resty-template** is a compiling (1, 2, 3) and transpiling (HTML) templating engine for Lua and OpenResty with sandboxing in mind (2, 3, 4).
 
-(1) with compilation we mean that templates are translated to Lua functions that you may call or `string.dump`
-as a binary bytecode blobs to disk that can be later utilized with `lua-resty-template` or basic `load` and
-`loadfile` standard Lua functions (see also [Template Precompilation](#template-precompilation)). Although,
+(1) with compilation we mean that templates are JIT- or (2) AOT-compiled to Lua functions that you may call (JIT) or `string.dump`
+as a binary bytecode blobs to disk (AOT) (2) that can be later utilized with `lua-resty-template` or basic `load` and
+`loadfile` standard Lua functions (see also [Template Precompilation](#template-precompilation) and (2) for constraints). Although,
 generally you don't need to do that as `lua-resty-template` handles this behind the scenes.
 
+(2) in sandboxed environments (such as wasm or luau), AOT-compiling (`template.precompile`) may not be possible due to the possible absence of `string.dump`. In such cases, `template.precompile` is not available and this library can just be used for its JIT-compilation or transpilation capability in your projects.
+
+(3) as this library is a JIT-based compiler, the minimum sandbox requires JIT-support with `load` (or `loadstring` with `setfenv`).
+
+(4) graceful protections and stubs for sandboxed IO are provided as file-loading/writing may be missing in your environment.
 
 ## Hello World with lua-resty-template
 
@@ -536,7 +541,7 @@ You may want to flush cache with `template.cache = {}` to ensure that your templ
 
 #### function, boolean template.compile(view, cache_key, plain)
 
-Parses, compiles and caches (if caching is enabled) a template and returns the compiled template as a function
+Parses, JIT-compiles (1) and caches (if caching is enabled) a template and returns the JIT-compiled (1) template as a function
 that takes context as a parameter and returns rendered template as a string. Optionally you may pass `cache_key` that
 is used as a cache key. If cache key is not provided `view` wil be used as a cache key. If cache key is `no-cache`
 the template cache will not be checked and the resulting function will not be cached. You may also optionally
@@ -727,7 +732,7 @@ Calculation: 10
 
 #### string template.process(view, context, cache_key, plain)
 
-Parses, compiles, caches (if caching is enabled) and returns output as string. You may optionally also
+Parses, JIT-compiles (1), caches (if caching is enabled) and returns output as string. You may optionally also
 pass `cache_key` that is used as a cache key. If `plain` evaluates to `true`, the `view` is considered
 to be plain string template (`template.load` and binary chunk detection is skipped on `template.parse`).
 If `plain` is `false"` the template is considered to be a file, and all the issues with file reading are
@@ -751,7 +756,7 @@ This just calls `template.process(view, context, cache_key, false)`
 
 #### template.render(view, context, cache_key, plain)
 
-Parses, compiles, caches (if caching is enabled) and outputs template either with `ngx.print` if available,
+Parses, JIT-compiles, caches (if caching is enabled) and outputs template either with `ngx.print` if available,
 or `print`. You may optionally also pass `cache_key` that is used as a cache key. If `plain` evaluates to
 `true`, the `view` is considered to be plain string template (`template.load` and binary chunk detection
 is skipped on `template.parse`). If `plain` is `false"` the template is considered to be a file, and
@@ -776,7 +781,7 @@ This just calls `template.render(view, context, cache_key, false)`
 
 #### string template.parse(view, plain)
 
-Parses template file or string, and generates a parsed template string. This may come useful when debugging
+Parses template file or string by transpiling it to Lua. This may come useful when debugging
 templates. You should note that if you are trying to parse a binary chunk (e.g. one returned with
 `template.compile`), `template.parse` will return that binary chunk as is. If `plain` evaluates to
 `true`, the `view` is considered to be plain string template (`template.load` and binary chunk detection
@@ -802,13 +807,13 @@ This just calls `template.parse(view, plain, false)`
 
 #### string template.precompile(view, path, strip, plain)
 
-Precompiles template as a binary chunk. This binary chunk can be written out as a file (and you may use it
+(2) AOT-compiles template to a bytecode binary chunk. This binary chunk can be written out as a file (and you may use it
 directly with Lua's `load` and `loadfile`). For convenience you may optionally specify `path` argument to
 output binary chunk to file. You may also supply `strip` parameter with value of `false` to make precompiled
 templates to have debug information as well (defaults to `true`). The last parameter `plain` means that
 should complilation treat the `view` as `string` (`plain = true`) or as `file path` (`plain = false`) or
 try first as a file, and fallback to `string` (`plain = nil`). In case the `plain=false` (a file) and there
-is error with `file io` the function will also error with an assertion failure. 
+is error with `file io` the function will also error with an assertion failure.
 
 ```lua
 local view = [[
@@ -949,8 +954,9 @@ end
 
 
 ## Template Precompilation
+- *see (2) for sandbox constraints*
 
-`lua-resty-template` supports template precompilation. This can be useful when you want to
+`lua-resty-template` supports template precompilation (AOT-compiling) (2). This can be useful when you want to
 skip template parsing (and Lua interpretation) in production or if you do not want your
 templates distributed as plain text files on production servers. Also by precompiling,
 you can ensure that your templates do not contain something, that cannot be compiled

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ template.render([[
   - [string template.parse(view, plain)](#string-templateparseview-plain)
   - [string template.parse_string(view, plain)](#string-templateparse_stringview-plain)
   - [string template.parse_file(view, plain)](#string-templateparse_fileview-plain)
-  - [string template.precompile(view, path, strip)](#string-templateprecompileview-path-strip)
-  - [string template.precompile_string(view, path, strip)](#string-templateprecompile_stringview-path-strip)
-  - [string template.precompile_file(view, path, strip)](#string-templateprecompile_fileview-path-strip)  
+  - [string template.precompile(view, path, strip, plain) **_\*(4)_**](#string-templateprecompileview-path-strip-plain)
+  - [string template.precompile_string(view, path, strip) **_\*(4)_**](#string-templateprecompile_stringview-path-strip)
+  - [string template.precompile_file(view, path, strip) **_\*(4)_**](#string-templateprecompile_fileview-path-strip)  
   - [string template.load(view, plain)](#string-templateloadview-plain)
   - [string template.load_string(view)](#string-templateload_stringview)
   - [string template.load_file(view)](#string-templateload_fileview)
@@ -806,6 +806,7 @@ This just calls `template.parse(view, plain, false)`
 
 
 #### string template.precompile(view, path, strip, plain)
+- If `io.open` is unavailable (4): `string template.precompile(view, strip, plain)`
 
 (2) AOT-compiles template to a bytecode binary chunk. This binary chunk can be written out as a file (and you may use it
 directly with Lua's `load` and `loadfile`). For convenience you may optionally specify `path` argument to
@@ -841,11 +842,13 @@ template.render("precompiled-bin.html", {
 
 
 #### string template.precompile_string(view, path, strip)
+- If `io.open` is unavailable (4): `string template.precompile_string(view, strip)`
 
 This just calls `template.precompile(view, path, strip, true)`.
 
 
 #### string template.precompile_file(view, path, strip)
+- If `io.open` is unavailable (4): `string template.precompile_file(view, path, strip)`
 
 This just calls `template.precompile(view, path, strip, false)`.
 

--- a/lib/resty/template.lua
+++ b/lib/resty/template.lua
@@ -1,37 +1,57 @@
--- SANDBOX CHECKS
-local IO_WRITE_PRESENT = io and type(io.write) == "function"
-local IO_OPEN_PRESENT = io and type(io.open) == "function"
-
 -- FUNCTION POLLUTION PROTECTION
+local getmetatable = getmetatable
 local setmetatable = setmetatable
-local loadstring = loadstring
 local tostring = tostring
-local setfenv = setfenv
-local require = require
 local concat = table.concat
 local assert = assert
 local pcall = pcall
-local phase
-local load = load
 local type = type
 local dump = string.dump
 local find = string.find
 local gsub = string.gsub
 local byte = string.byte
-local null
 local sub = string.sub
 local ngx = ngx
 local jit = jit
-local var
 
--- VAR POLLUTION PROTECTION
-local _VERSION = _VERSION
+-- NOT SANDBOX-PROTECTED:
+local loadstring = loadstring
+local setfenv = setfenv
+local load = load
+
+-- SANDBOX-PROTECTED: STUBBED LATER
+local require = require
 local _ENV = _ENV -- luacheck: globals _ENV
 local _G = _G
 
--- SANDBOX STUBBING
+-- SANDBOXING: PRESENCE CHECKS
+local function is_callable(value)
+    if type(value) == "function" then
+        return true
+    end
+    local mt = getmetatable(mt.__call)
+    return mt and type(mt.__call) == "function"
+end
+local IO_WRITE_PRESENT    = io and is_callable(io.write)
+local IO_OPEN_PRESENT     = io and is_callable(io.open)
+local SETFENV_PRESENT     = is_callable(setfenv)
+local LOADSTRING_PRESENT  = is_callable(loadstring)
+local LOAD_PRESENT        = is_callable(load)
+local REQUIRE_PRESENT     = is_callable(require)
+local _ENV_PRESENT        = not not _ENV
+local _G_PRESENT          = not not _G
+
+-- SANDBOX-PROTECTED: STUBBED NOW
 local write_print = (IO_WRITE_PRESENT and io.open) or function(...) print(table.concat({...}, "")) end
 local open = (IO_OPEN_PRESENT and io.open) or function(filename, mode) return nil, "io.open is not permitted in this environment" end
+
+-- VAR POLLUTION PROTECTION
+local _VERSION = _VERSION
+
+-- NORMAL LOCALS
+local phase
+local null
+local var
 
 local HTML_ENTITIES = {
     ["&"] = "&amp;",

--- a/lib/resty/template.lua
+++ b/lib/resty/template.lua
@@ -5,10 +5,8 @@ local setfenv = setfenv
 local require = require
 local concat = table.concat
 local assert = assert
-local write = io.write
 local pcall = pcall
 local phase
-local open = io.open
 local load = load
 local type = type
 local dump = string.dump
@@ -24,6 +22,9 @@ local var
 local _VERSION = _VERSION
 local _ENV = _ENV -- luacheck: globals _ENV
 local _G = _G
+
+local write_print = (io and io.write) or function(...) print(table.concat({...}, "")) end
+local open = (io and io.open) or function(filename, mode) return nil, "io.open is not permitted in this environment" end
 
 local HTML_ENTITIES = {
     ["&"] = "&amp;",
@@ -127,7 +128,7 @@ end
 local print_view
 local load_view
 if ngx then
-    print_view = ngx.print or write
+    print_view = ngx.print or write_print
 
     var = ngx.var
     null = ngx.null
@@ -177,7 +178,7 @@ if ngx then
         end
     end
 else
-    print_view = write
+    print_view = write_print
     load_view = function(template)
         return function(view, plain)
             if plain == true then return view end

--- a/lib/resty/template.lua
+++ b/lib/resty/template.lua
@@ -66,7 +66,7 @@ local PERCNT = byte("%")
 local EMPTY  = ""
 
 local VIEW_ENV
-if _VERSION == "Lua 5.1" then
+if _VERSION == "Lua 5.1" or _VERSION == "Luau" then
     VIEW_ENV = { __index = function(t, k)
         return t.context[k] or t.template[k] or _G[k]
     end }

--- a/lib/resty/template.lua
+++ b/lib/resty/template.lua
@@ -23,8 +23,8 @@ local _VERSION = _VERSION
 local _ENV = _ENV -- luacheck: globals _ENV
 local _G = _G
 
-local write_print = (io and io.write) or function(...) print(table.concat({...}, "")) end
-local open = (io and io.open) or function(filename, mode) return nil, "io.open is not permitted in this environment" end
+local write_print = (io and type(io.write) == "function") or function(...) print(table.concat({...}, "")) end
+local open = (io and type(io.open) == "function") or function(filename, mode) return nil, "io.open is not permitted in this environment" end
 
 local HTML_ENTITIES = {
     ["&"] = "&amp;",

--- a/lib/resty/template.lua
+++ b/lib/resty/template.lua
@@ -1,3 +1,8 @@
+-- SANDBOX CHECKS
+local IO_WRITE_PRESENT = io and type(io.write) == "function"
+local IO_OPEN_PRESENT = io and type(io.open) == "function"
+
+-- FUNCTION POLLUTION PROTECTION
 local setmetatable = setmetatable
 local loadstring = loadstring
 local tostring = tostring
@@ -19,12 +24,14 @@ local ngx = ngx
 local jit = jit
 local var
 
+-- VAR POLLUTION PROTECTION
 local _VERSION = _VERSION
 local _ENV = _ENV -- luacheck: globals _ENV
 local _G = _G
 
-local write_print = (io and type(io.write) == "function") or function(...) print(table.concat({...}, "")) end
-local open = (io and type(io.open) == "function") or function(filename, mode) return nil, "io.open is not permitted in this environment" end
+-- SANDBOX STUBBING
+local write_print = (IO_WRITE_PRESENT and io.open) or function(...) print(table.concat({...}, "")) end
+local open = (IO_OPEN_PRESENT and io.open) or function(filename, mode) return nil, "io.open is not permitted in this environment" end
 
 local HTML_ENTITIES = {
     ["&"] = "&amp;",

--- a/lib/resty/template.lua
+++ b/lib/resty/template.lua
@@ -12,7 +12,6 @@ local gsub = string.gsub
 local byte = string.byte
 local sub = string.sub
 local ngx = ngx
-local jit = jit
 
 -- NOT SANDBOX-PROTECTED:
 local loadstring = loadstring
@@ -44,9 +43,6 @@ local _G_PRESENT          = not not _G
 -- SANDBOX-PROTECTED: STUBBED NOW
 local write_print = (IO_WRITE_PRESENT and io.open) or function(...) print(table.concat({...}, "")) end
 local open = (IO_OPEN_PRESENT and io.open) or function(filename, mode) return nil, "io.open is not permitted in this environment" end
-
--- VAR POLLUTION PROTECTION
-local _VERSION = _VERSION
 
 -- NORMAL LOCALS
 local phase
@@ -94,13 +90,17 @@ local PERCNT = byte("%")
 local EMPTY  = ""
 
 local VIEW_ENV
-if _VERSION == "Lua 5.1" or _VERSION == "Luau" then
+if _G_PRESENT then
     VIEW_ENV = { __index = function(t, k)
         return t.context[k] or t.template[k] or _G[k]
     end }
-else
+elseif _ENV_PRESENT
     VIEW_ENV = { __index = function(t, k)
         return t.context[k] or t.template[k] or _ENV[k]
+    end }
+else -- optimized sandboxed def
+    VIEW_ENV = { __index = function(t, k)
+        return t.context[k] or t.template[k]
     end }
 end
 
@@ -229,13 +229,13 @@ local function load_string(func)
 end
 
 local loader
-if jit or _VERSION ~= "Lua 5.1" then
+if LOAD_PRESENT then
     loader = function(template)
         return function(view)
             return assert(load(view, nil, nil, setmetatable({ template = template }, VIEW_ENV)))
         end
     end
-else
+elseif LOADSTRING_PRESENT
     loader = function(template)
         return function(view)
             local func = assert(loadstring(view))
@@ -243,6 +243,8 @@ else
             return func
         end
     end
+else
+    error("Dynamic template loading is not supported in this Lua environment")
 end
 
 local function visit(visitors, content, tag, name)

--- a/lib/resty/template.lua
+++ b/lib/resty/template.lua
@@ -391,23 +391,37 @@ local function new(template, safe)
         })
     end
 
-    if STRING_DUMP_PRESENT and IO_OPEN_PRESENT then
-        function template.precompile(view, path, strip, plain)
-            local chunk = dump(template.compile(view, nil, plain), strip ~= false)
-            if path then
-                local file = open(path, "wb")
-                file:write(chunk)
-                file:close()
+    if STRING_DUMP_PRESENT then
+        if IO_OPEN_PRESENT then
+            function template.precompile(view, path, strip, plain)
+                local chunk = dump(template.compile(view, nil, plain), strip ~= false)
+                if path then
+                    local file = open(path, "wb")
+                    file:write(chunk)
+                    file:close()
+                end
+                return chunk
             end
-            return chunk
-        end
-    
-        function template.precompile_string(view, path, strip)
-            return template.precompile(view, path, strip, true)
-        end
-    
-        function template.precompile_file(view, path, strip)
-            return template.precompile(view, path, strip, false)
+        
+            function template.precompile_string(view, path, strip)
+                return template.precompile(view, path, strip, true)
+            end
+        
+            function template.precompile_file(view, path, strip)
+                return template.precompile(view, path, strip, false)
+            end
+        else
+            function template.precompile(view, strip, plain)
+                return dump(template.compile(view, nil, plain), strip ~= false)
+            end
+        
+            function template.precompile_string(view, strip)
+                return template.precompile(view, strip, true)
+            end
+        
+            function template.precompile_file(view, strip)
+                return template.precompile(view, strip, false)
+            end
         end
     end
 

--- a/lib/resty/template.lua
+++ b/lib/resty/template.lua
@@ -6,7 +6,6 @@ local concat = table.concat
 local assert = assert
 local pcall = pcall
 local type = type
-local dump = string.dump
 local find = string.find
 local gsub = string.gsub
 local byte = string.byte
@@ -20,6 +19,7 @@ local load = load
 
 -- SANDBOX-PROTECTED: STUBBED LATER
 local require = require
+local dump = string.dump
 local _ENV = _ENV -- luacheck: globals _ENV
 local _G = _G
 
@@ -37,6 +37,7 @@ local SETFENV_PRESENT     = is_callable(setfenv)
 local LOADSTRING_PRESENT  = is_callable(loadstring)
 local LOAD_PRESENT        = is_callable(load)
 local REQUIRE_PRESENT     = is_callable(require)
+local STRING_DUMP_PRESENT = is_callable(dump)
 local _ENV_PRESENT        = not not _ENV
 local _G_PRESENT          = not not _G
 
@@ -390,22 +391,24 @@ local function new(template, safe)
         })
     end
 
-    function template.precompile(view, path, strip, plain)
-        local chunk = dump(template.compile(view, nil, plain), strip ~= false)
-        if path then
-            local file = open(path, "wb")
-            file:write(chunk)
-            file:close()
+    if STRING_DUMP_PRESENT and IO_OPEN_PRESENT then
+        function template.precompile(view, path, strip, plain)
+            local chunk = dump(template.compile(view, nil, plain), strip ~= false)
+            if path then
+                local file = open(path, "wb")
+                file:write(chunk)
+                file:close()
+            end
+            return chunk
         end
-        return chunk
-    end
-
-    function template.precompile_string(view, path, strip)
-        return template.precompile(view, path, strip, true)
-    end
-
-    function template.precompile_file(view, path, strip)
-        return template.precompile(view, path, strip, false)
+    
+        function template.precompile_string(view, path, strip)
+            return template.precompile(view, path, strip, true)
+        end
+    
+        function template.precompile_file(view, path, strip)
+            return template.precompile(view, path, strip, false)
+        end
     end
 
     function template.compile(view, cache_key, plain)


### PR DESCRIPTION
- adds `_VERSION` check fix for Luau (the targeted sandbox, which is 5.1 compliant)
- adds stubs for:
  - `io.open`
  - `io.write`